### PR TITLE
fix isActive bug when prefix is empty or null

### DIFF
--- a/src/Supports/BaseMenu.php
+++ b/src/Supports/BaseMenu.php
@@ -90,7 +90,7 @@ abstract class BaseMenu
     public function getIsActive()
     {
         if (property_exists(get_called_class(), 'isActive')) {
-            return  config('ladmin.prefix') . '/' . ltrim($this->isActive, '/');
+            return  ltrim(config('ladmin.prefix') . '/' . $this->isActive, '/');
         }
 
         return config('ladmin.prefix') . '/';


### PR DESCRIPTION
This fix remove leading forward slash when prefix in `ladmin.php` is empty or null. The [hexters/ladmin](https://github.com/hexters/ladmin) sidebar active menu won't work because $isActive defined doesn't match due to leading forward slash `/`.

```php
// $isActive = 'abcd'

return  config('ladmin.prefix') . '/' . ltrim($this->isActive, '/');
// when 'prefix' => 'administrator', return 'administrator/abcd'
// when 'prefix' => '', return '/abcd'

return  ltrim(config('ladmin.prefix') . '/' . $this->isActive, '/');
// when 'prefix' => 'administrator', return 'administrator/abcd'
// when 'prefix' => '', return 'abcd'
```